### PR TITLE
refactor: remove dataset_id in get_variable_contributions

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -290,26 +290,21 @@ get_avatars <- function(job_id, get_result_timeout = 10, download_timeout = 100)
 #' Get contributions of the dataset variables within the fitted space
 #'
 #' @param job_id The job id for this avatarization
-#' @param dataset_id An identifier for the uploaded dataset
 #'
 #' @return contributions dataframe
 #' @export
 #'
 #' @examples
 #' \dontrun{
-#' get_variable_contributions(job_id, dataset_id) # for original dataset
-#' get_variable_contributions(job_id, job_result$avatars_dataset$id) # for avatars dataset
+#' get_variable_contributions(job_id) # for original dataset
 #' }
-get_variable_contributions <- function(job_id, dataset_id) {
+get_variable_contributions <- function(job_id) {
   if (is.null(job_id)) {
     stop("expected valid job_id, got null instead")
   }
 
-  if (is.null(dataset_id)) {
-    stop("expected valid dataset_id, got null instead")
-  }
 
-  endpoint <- paste0("/contributions?job_id=", job_id, "&dataset_id=", dataset_id)
+  endpoint <- paste0("/contributions?job_id=", job_id)
 
   response <- .do_http("GET", endpoint)
 

--- a/integration_test/run_complete.R
+++ b/integration_test/run_complete.R
@@ -31,7 +31,7 @@ run_single <- function(df, label) {
   print(sensitive_unshuffled_avatars)
 
   # Get metrics of the avatarization
-  res <- get_variable_contributions(job$id, dataset_id)
+  res <- get_variable_contributions(job$id)
   res <- get_projections(job$id)
   res <- get_explained_variance(job$id)
 

--- a/man/get_variable_contributions.Rd
+++ b/man/get_variable_contributions.Rd
@@ -4,12 +4,10 @@
 \alias{get_variable_contributions}
 \title{Get contributions of the dataset variables within the fitted space}
 \usage{
-get_variable_contributions(job_id, dataset_id)
+get_variable_contributions(job_id)
 }
 \arguments{
 \item{job_id}{The job id for this avatarization}
-
-\item{dataset_id}{An identifier for the uploaded dataset}
 }
 \value{
 contributions dataframe
@@ -19,7 +17,6 @@ Get contributions of the dataset variables within the fitted space
 }
 \examples{
 \dontrun{
-get_variable_contributions(job_id, dataset_id) # for original dataset
-get_variable_contributions(job_id, job_result$avatars_dataset$id) # for avatars dataset
+get_variable_contributions(job_id) # for original dataset
 }
 }


### PR DESCRIPTION
BREAKING: This parameter is unnecessary as avatarized datasets do not
contribute to the projections, so there is no need to accept
another a dataset_id as argument, as we are only ever going
to use the original dataset_id from the job.
